### PR TITLE
22 Handle file uploads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    types: [opened, closed]
+    types: [opened, synchronize, closed]
     branches:
       - main
 env:


### PR DESCRIPTION
File uploads are handled automatically by Phoenix. An uploaded file is saved in a temporay file and its info is saved in the context in a Plug.

Ideally, the service would simply forward the file without reading it from the file, but that seemed to require a lot of work for very little reward.Since this service will eventually be replaced by an actual API Gateway or added to other services, the effort was not considered necessary.