### PR TITLE
22 handle file upload requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    types: [opened, closed]
+    types: [opened, synchronize, closed]
     branches:
       - main
 env:

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ users-*.tar
 release.ex
 
 .env*
+
+**/.DS_Store

--- a/lib/users_web/controllers/user_controller.ex
+++ b/lib/users_web/controllers/user_controller.ex
@@ -40,13 +40,16 @@ defmodule UsersWeb.UserController do
 
   def create(conn, _, user_params) do
     case Accounts.create_user(user_params) do
-      { :ok, %User{} = user } ->
+      {:ok, %User{} = user} ->
         Events.new_user(user_params)
+
         conn
         |> put_status(:created)
         |> render(:show, user: user)
-        # TODO return a better error message
-      {:error, _} -> send_resp(conn, 422, "error")
+
+      # TODO return a better error message
+      {:error, _} ->
+        send_resp(conn, 422, "error")
     end
   end
 
@@ -109,7 +112,7 @@ defmodule UsersWeb.UserController do
     } = conn.body_params["filename"]
 
     form = [
-      {:file, file_path, {"form-data", [name: "data", filename: filename]},
+      {:file, file_path, {"form-data", [name: "file", filename: filename]},
        [{"Content-Type", file_content_type}]}
     ]
 


### PR DESCRIPTION
This MR has changes such that when a file is uploaded, the uploaded file is relayed to the api. Unfortunately, There was no easy way of relaying the data as they came in, so now the entire is file is
1. saved to desk
2. read from desk
3. sent to API

Saving to desk is done automatically by Phoenix.