### PR TITLE
#21 returning 404 for non existent users

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -15,7 +15,9 @@ port = String.to_integer(System.get_env("PORT", "4000"))
 
 config :users, UsersWeb.Endpoint,
   http: [ip: {0, 0, 0, 0}, port: port],
-  secret_key_base: secret_key_base
+  secret_key_base: secret_key_base,
+  code_reloader: true,
+  debug_errors: true
 
 config :users, UsersWeb.Auth.Guardian,
   issues: "users_app",
@@ -34,7 +36,8 @@ config :users, Redix,
 
 config :users, Users.Mailer,
   adapter: Swoosh.Adapters.AmazonSES,
-  region: System.get_env("REGION", "us-east-1"),
+  region: System.get_env("AWS_REGION", "us-east-1"),
+  # TODO Move keys to runtime.exs
   access_key: System.get_env("AWS_SES_ACCESS_KEY"),
   secret: System.get_env("AWS_SES_SECRET_ACCESS_KEY")
 

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,3 @@
+-- Create spaced_repetition if it doesn't exist
+SELECT 'CREATE DATABASE spaced_repetition' 
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'spaced_repetition')\gexec

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@
 
 version: '3.9' # optional since v1.27.0
 services:
-  redis:
+  cache:
     image: redis:7
     ports:
       - 6379:6379
@@ -12,9 +12,9 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - ./sql/db.sql:/docker-entrypoint-initdb.d/db.sql
-    environment:
-      POSTGRES_PASSWORD: postgres
+      - ./db:/docker-entrypoint-initdb.d/
+    env_file:
+      - .env.dev
 
   api:
     depends_on:
@@ -25,11 +25,7 @@ services:
     env_file:
       - .env.dev
     environment:
-      POSTGRES_HOSTNAME: db
       PORT: 5000
-      POSTGRES_PASSWORD: postgres
-      DB_NAME: spaced_repetition
-      DATABASE_URL: ecto://postgres:postgres@db/spaced_repetition
 
   auth:
     depends_on:
@@ -44,11 +40,5 @@ services:
     env_file:
       - .env.dev
     environment:
-      VERIFICATION_URL: localhost:3000
-      APP_ENDPOINT: api:5000
-      REDIS_HOST: redis
-      POSTGRES_HOSTNAME: db
       PORT: 4000
-      POSTGRES_DB: spaced_repetition
-      POSTGRES_PASSWORD: postgres
     entrypoint: ./init.sh

--- a/lib/users/accounts.ex
+++ b/lib/users/accounts.ex
@@ -24,18 +24,18 @@ defmodule Users.Accounts do
   @doc """
   Gets a single user.
 
-  Raises `Ecto.NoResultsError` if the User does not exist.
+  Return nil if the User does not exist.
 
   ## Examples
 
-      iex> get_user!(123)
+      iex> get_user(123)
       %User{}
 
-      iex> get_user!(456)
-      ** (Ecto.NoResultsError)
+      iex> get_user(456)
+      ** nil
 
   """
-  def get_user!(id), do: Repo.get!(User, id)
+  def get_user(id), do: Repo.get(User, id)
 
   @doc """
   Gets a single user by email

--- a/lib/users_web/auth/guardian.ex
+++ b/lib/users_web/auth/guardian.ex
@@ -18,7 +18,7 @@ defmodule UsersWeb.Auth.Guardian do
   # See https://hexdocs.pm/ecto/Ecto.Repo.html#c:update_all/3
   # See https://elixirforum.com/t/ecto-why-repo-get-before-repo-update/12043/2
   def resource_from_claims(%{"sub" => id}) do
-    case Accounts.get_user!(id) do
+    case Accounts.get_user(id) do
       nil -> {:error, :user_not_found}
       user -> {:ok, user}
     end

--- a/lib/users_web/auth/guardian_error_handler.ex
+++ b/lib/users_web/auth/guardian_error_handler.ex
@@ -2,12 +2,7 @@ defmodule UsersWeb.Auth.GuardianErrorHandler do
   import Plug.Conn
   require Logger
 
-  def auth_error(conn, {type, _reason}, _opts) do
-    body = Jason.encode!(%{error: to_string(type)})
-
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(401,body)
-
+  def auth_error(conn, _, _) do
+    send_resp(conn, :unauthorized, "")
   end
 end

--- a/sql/db.sql
+++ b/sql/db.sql
@@ -1,1 +1,0 @@
-CREATE DATABASE spaced_repetition;

--- a/test/users/accounts_test.exs
+++ b/test/users/accounts_test.exs
@@ -15,7 +15,7 @@ defmodule Users.AccountsTest do
 
     test "get_user!/1 returns the user with given id" do
       user = insert(:user)
-      assert Accounts.get_user!(user.id) == user
+      assert Accounts.get_user(user.id) == user
     end
 
     test "get_user_by_email/1 returns user with given email" do
@@ -46,14 +46,16 @@ defmodule Users.AccountsTest do
     test "update_user/2 with invalid data returns error changeset" do
       user = insert(:user)
       assert {:error, %Ecto.Changeset{}} = Accounts.update_user(user, @invalid_attrs)
-      assert user == Accounts.get_user!(user.id)
+      assert user == Accounts.get_user(user.id)
     end
 
     # TODO: Archive users
     test "delete_user/1 deletes the user" do
       user = insert(:user)
       assert {:ok, %User{}} = Accounts.delete_user(user)
-      assert_raise Ecto.NoResultsError, fn -> Accounts.get_user!(user.id) end
+      # Using match? to assert nill
+      # See https://hexdocs.pm/ex_unit/1.12.3/ExUnit.Assertions.html#assert/2
+      assert match?(nil, Accounts.get_user(user.id))
     end
 
     test "change_user/1 returns a user changeset" do


### PR DESCRIPTION
This MR makes sure that for a non-existent user, the calls are not forwarded and a 401 is returned.

Closes #21 