### PR TITLE
29 Move health check to plug.

### DIFF
--- a/lib/users_web/plugs/health.ex
+++ b/lib/users_web/plugs/health.ex
@@ -1,0 +1,15 @@
+defmodule UsersWeb.Plugs.Health do
+  import Plug.Conn
+
+  def init(default), do: default
+
+  def call(%Plug.Conn{request_path: "/health"} = conn, _opts) do
+    conn
+    |> send_resp(200, "healthy")
+    |> halt()
+  end
+
+  def call(conn, _) do
+    conn
+  end
+end


### PR DESCRIPTION
Move the health check to a plug so our business logic is a bit cleaner and Phoenix does not log the health check.

Closes #29 