### PR TITLE
#35 Add ecs service restart step.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,3 +90,15 @@ jobs:
           docker push $REPO/$IMAGE_NAME
           docker tag $REPO/$IMAGE_NAME $REPO/$IMAGE_NAME:${GITHUB_SHA::6}
           docker push $REPO/$IMAGE_NAME:${GITHUB_SHA::6}
+  deploy:
+      needs: 
+        - release
+      runs-on: ubuntu-22.04
+      name: Deploy
+      steps:
+        - name: Restart ECS Service
+          run: aws ecs update-service --cluster sp --service sp-auth --force-new-deployment
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_SECRET_KEY }}
+        AWS_DEFAULT_REGION: ${{ vars.REGION }}


### PR DESCRIPTION
This MR adds a step to redeploy the user management ecs service after a pull request has been merged and new docker image has been released. Restarting the ecs service ensures that it has the latest image.

Closes #35 