### PR TITLE
41 add endpoint to reset forgotten password

### DIFF
--- a/lib/users_web/auth/auth.ex
+++ b/lib/users_web/auth/auth.ex
@@ -44,7 +44,7 @@ defmodule UsersWeb.Auth do
     UsersWeb.Auth.Tokens.set(token)
   end
 
-  def is_forgotten_password?(token) do
+  def forgotten_password?(token) do
     cached_tokens = UsersWeb.Auth.Tokens.exists!(token)
     cached_tokens != 0
   end

--- a/lib/users_web/auth/auth.ex
+++ b/lib/users_web/auth/auth.ex
@@ -39,4 +39,13 @@ defmodule UsersWeb.Auth do
   def blacklist_token(token) do
     UsersWeb.Auth.Tokens.blacklist!(token)
   end
+
+  def save_forgotten_token(token) do
+    UsersWeb.Auth.Tokens.set(token)
+  end
+
+  def is_forgotten_password?(token) do
+    cached_tokens = UsersWeb.Auth.Tokens.exists!(token)
+    cached_tokens != 0
+  end
 end

--- a/lib/users_web/auth/error_handler.ex
+++ b/lib/users_web/auth/error_handler.ex
@@ -1,8 +1,8 @@
 defmodule UsersWeb.Auth.ErrorHandler do
   import Plug.Conn
-  require Logger
 
   def auth_error(conn, _, _) do
+    # TODO(44) Remove this after error controller created
     send_resp(conn, :unauthorized, "")
   end
 end

--- a/lib/users_web/auth/error_response.ex
+++ b/lib/users_web/auth/error_response.ex
@@ -1,3 +1,4 @@
+# TODO (44) Remove after error controller has been implemented
 defmodule UsersWeb.Auth.ErrorResponse.Unauthorized do
-  defexception [message: "Unauthorized", plug_status: 401]
+  defexception message: "Unauthorized", plug_status: 401
 end

--- a/lib/users_web/auth/tokens.ex
+++ b/lib/users_web/auth/tokens.ex
@@ -7,6 +7,10 @@ defmodule UsersWeb.Auth.Tokens do
     Redix.command!(:tokens, ["DEL", token])
   end
 
+  def set(token) do
+    Redix.command(:tokens, ["SETEX", token, 7 * 24 * 60 * 60, 0])
+  end
+
   def blacklist!(token) do
     # TODO Set expiry time in config
     Redix.command!(:tokens, ["SETEX", token, 7 * 24 * 60 * 60, 0])

--- a/lib/users_web/controllers/user_controller.ex
+++ b/lib/users_web/controllers/user_controller.ex
@@ -66,6 +66,11 @@ defmodule UsersWeb.UserController do
       conn
       |> put_status(:ok)
       |> render(:token, token: token)
+    else
+      _ ->
+        conn
+        |> put_resp_content_type("application/text")
+        |> send_resp(401, "Wrong email and/or password.")
     end
   end
 
@@ -92,7 +97,7 @@ defmodule UsersWeb.UserController do
     user = Guardian.Plug.current_resource(conn)
 
     with {:ok, _} <- Accounts.update_user(user, body_params) do
-      send_resp(conn, 200, "")
+      conn |> put_resp_content_type("application/text") |> send_resp(200, "Password reset")
     end
   end
 

--- a/lib/users_web/controllers/user_controller.ex
+++ b/lib/users_web/controllers/user_controller.ex
@@ -87,6 +87,14 @@ defmodule UsersWeb.UserController do
     end
   end
 
+  def reset_password(conn, _, body_params) do
+    user = Guardian.Plug.current_resource(conn)
+
+    with {:ok, _} <- Accounts.update_user(user, body_params) do
+      send_resp(conn, 200, "")
+    end
+  end
+
   def forward(conn, _, _) do
     http = Application.get_env(:users, :http)
 

--- a/lib/users_web/controllers/user_controller.ex
+++ b/lib/users_web/controllers/user_controller.ex
@@ -79,7 +79,8 @@ defmodule UsersWeb.UserController do
 
   def forgot_password(conn, _, body_params) do
     with {:ok, user} <- Accounts.get_user_by_email(body_params["email"]),
-         {:ok, token, _} <- Auth.get_token(user) do
+         {:ok, token, _} <- Auth.get_token(user),
+         {:ok, _} <- Auth.save_forgotten_token(token) do
       Worker.forgot_password(%{email: user.email, token: token})
       send_resp(conn, 200, "")
     else

--- a/lib/users_web/controllers/user_controller.ex
+++ b/lib/users_web/controllers/user_controller.ex
@@ -1,3 +1,6 @@
+# TODO Use Account.get_user instead of Guardian.Plug.current_resource. Move resource
+# access to accounts context, and finally change account context so that only id
+# is accepted where entire user entity passed
 defmodule UsersWeb.UserController do
   use UsersWeb, :controller
   import Plug.Conn
@@ -22,6 +25,23 @@ defmodule UsersWeb.UserController do
     render(conn, :show, user: user)
   end
 
+  # TODO reverse order of user creation and token creation
+  # If user is created and token creation fails, then db is in a bad
+  # state. Reversal makes user creation an atomic operation
+  def create(conn, _, user_params) do
+    with {:ok, user} <- Accounts.create_user(user_params),
+         {:ok, token, _} <- Auth.get_token(user) do
+      Worker.new_user(%{email: user.email, token: token})
+
+      conn
+      |> put_status(:created)
+      |> render(:show, user: user)
+    else
+      # TODO (44) move this to errors controller
+      _ -> send_resp(conn, 422, "Invalid user data provide.")
+    end
+  end
+
   def update(conn, _, user_params) do
     user = Guardian.Plug.current_resource(conn)
 
@@ -38,26 +58,12 @@ defmodule UsersWeb.UserController do
     end
   end
 
-  # TODO reverse order of user creation and token creation
-  # If user is created and token creation fails, then db is in a bad
-  # state. Reversal makes user creation an atomic operation
-  def create(conn, _, user_params) do
-    with {:ok, user} <- Accounts.create_user(user_params),
-         {:ok, token, _} <- Auth.get_token(user) do
-      Worker.new_user(%{email: user.email, token: token})
-
-      conn
-      |> put_status(:created)
-      |> render(:show, user: user)
-    end
-  end
-
   def verify(conn, _, _) do
-    conn
-    |> Guardian.Plug.current_resource()
-    |> Accounts.verify_user()
+    user = Guardian.Plug.current_resource(conn)
 
-    send_resp(conn, :ok, "Your email has been verified.You can now login.")
+    with {:ok, _} <- Accounts.verify_user(user) do
+      send_resp(conn, :ok, "Your email has been verified.You can now login.")
+    end
   end
 
   def login(conn, _, %{"email" => email, "password" => raw_password}) do
@@ -67,10 +73,8 @@ defmodule UsersWeb.UserController do
       |> put_status(:ok)
       |> render(:token, token: token)
     else
-      _ ->
-        conn
-        |> put_resp_content_type("application/text")
-        |> send_resp(401, "Wrong email and/or password.")
+      # TODO (44) move this to errors controller
+      _ -> send_resp(conn, 401, "Wrong email and/or password.")
     end
   end
 
@@ -97,7 +101,7 @@ defmodule UsersWeb.UserController do
     user = Guardian.Plug.current_resource(conn)
 
     with {:ok, _} <- Accounts.update_user(user, body_params) do
-      conn |> put_resp_content_type("application/text") |> send_resp(200, "Password reset")
+      send_resp(conn, 200, "Password reset")
     end
   end
 

--- a/lib/users_web/endpoint.ex
+++ b/lib/users_web/endpoint.ex
@@ -2,6 +2,7 @@ defmodule UsersWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :users
 
   plug UsersWeb.Plugs.Health
+  plug UsersWeb.Plugs.ResetPassword
 
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.

--- a/lib/users_web/plugs/reset_password.ex
+++ b/lib/users_web/plugs/reset_password.ex
@@ -10,7 +10,7 @@ defmodule UsersWeb.Plugs.ResetPassword do
     is_forgotten_password =
       conn
       |> get_req_header("authorization")
-      |> Auth.is_forgotten_password?()
+      |> Auth.forgotten_password?()
 
     if is_forgotten_password, do: conn, else: raise(ErrorResponse.Unauthorized)
   end

--- a/lib/users_web/plugs/reset_password.ex
+++ b/lib/users_web/plugs/reset_password.ex
@@ -1,0 +1,19 @@
+defmodule UsersWeb.Plugs.ResetPassword do
+  import Plug.Conn
+
+  alias UsersWeb.Auth.ErrorResponse
+  alias UsersWeb.Auth
+
+  def init(default), do: default
+
+  def call(%Plug.Conn{request_path: "/reset-password"} = conn, _opts) do
+    is_forgotten_password =
+      conn
+      |> get_req_header("authorization")
+      |> Auth.is_forgotten_password?()
+
+    if is_forgotten_password, do: conn, else: raise(ErrorResponse.Unauthorized)
+  end
+
+  def call(conn, _opts), do: conn
+end

--- a/lib/users_web/plugs/verify.ex
+++ b/lib/users_web/plugs/verify.ex
@@ -12,6 +12,7 @@ defmodule UsersWeb.Plugs.Verify do
       |> get_req_header("authorization")
       |> Tokens.exists!()
 
+    # TODO(44) Instead of raising call proper error controller method
     if cached_tokens == 0, do: conn, else: raise(ErrorResponse.Unauthorized)
   end
 end

--- a/lib/users_web/router.ex
+++ b/lib/users_web/router.ex
@@ -24,6 +24,7 @@ defmodule UsersWeb.Router do
     put "/:id", UserController, :update
     get "/logout", UserController, :logout
     get "/deregister", UserController, :delete
+    post "/reset-password", UserController, :reset_password
   end
 
   scope "/users", UsersWeb do

--- a/test/users_web/controllers/user_controller_test.exs
+++ b/test/users_web/controllers/user_controller_test.exs
@@ -91,7 +91,6 @@ defmodule UsersWeb.UserControllerTest do
   end
 
   describe "POST /users/forgot-password" do
-    @tag :wip
     test "when user is registered", %{conn: conn} do
       %{conn: conn, user: user} = create_verified_user_conn(%{conn: conn})
 
@@ -118,6 +117,22 @@ defmodule UsersWeb.UserControllerTest do
     end
   end
 
+  describe "POST /users/reset-password" do
+    test "when user is registered", %{conn: conn} do
+      %{conn: conn} = create_verified_user_conn(%{conn: conn})
+      new_password = "newpassword"
+      conn = reset_password(conn, new_password)
+
+      assert response(conn, 200)
+    end
+
+    test "when user is not registered", %{conn: conn} do
+      conn = reset_password(conn, "newpassword")
+
+      assert response(conn, 401)
+    end
+  end
+
   describe "forward" do
     test "request forwarded", %{conn: conn} do
       http = Application.get_env(:users, :http)
@@ -135,6 +150,10 @@ defmodule UsersWeb.UserControllerTest do
 
   defp forgot_password(conn, email) do
     post(conn, ~p"/users/forgot-password", %{email: email})
+  end
+
+  defp reset_password(conn, password) do
+    post(conn, ~p"/users/reset-password", %{password: password})
   end
 
   defp create_user_conn(%{conn: conn, user_data: user_params}) do


### PR DESCRIPTION
This MR add a reset password endpoint. A password is reset ONLY if the token in the request header is cached when a forgot password call was made.

Closes #41 